### PR TITLE
Show `contribution.prompt_count` in "Total Prompts" instead of `contribution.post_count`

### DIFF
--- a/langcorrect/templates/contributions/partials/contribution.html
+++ b/langcorrect/templates/contributions/partials/contribution.html
@@ -36,7 +36,7 @@
             data-bs-placement="bottom"
             data-bs-title="{% translate 'Total Prompts' %}"
             class="ranking-item">
-        <i class="fa-solid fa-feather-pointed"></i> {{ contribution.post_count }}
+        <i class="fa-solid fa-feather-pointed"></i> {{ contribution.prompt_count }}
       </span>
       <span data-bs-toggle="tooltip"
             data-bs-placement="bottom"


### PR DESCRIPTION
It seems like `contribution.p`<kbd>Tab</kbd> auto-completed to the wrong variable.