### PR TITLE
Fix translation bug in notifications (#191)

### DIFF
--- a/langcorrect/corrections/views.py
+++ b/langcorrect/corrections/views.py
@@ -6,6 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as translate
+from django.utils.translation import gettext_noop
 from notifications.signals import notify
 
 from langcorrect.corrections.constants import FileFormat
@@ -88,7 +89,7 @@ def make_corrections(request, slug):
                 notify.send(
                     sender=current_user,
                     recipient=post.user,
-                    verb=translate("corrected"),
+                    verb=gettext_noop("corrected"),
                     action_object=post,
                     notification_type="new_correction",
                 )
@@ -96,7 +97,7 @@ def make_corrections(request, slug):
                 notify.send(
                     sender=current_user,
                     recipient=post.user,
-                    verb=translate("commented on"),
+                    verb=gettext_noop("commented on"),
                     action_object=post,
                     notification_type="new_comment",
                 )

--- a/langcorrect/follows/views.py
+++ b/langcorrect/follows/views.py
@@ -5,6 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from django.views.decorators.http import require_http_methods
 from django.views.generic import ListView
 from notifications.signals import notify
@@ -70,7 +71,7 @@ def follow_user(request, username):
         notify.send(
             sender=current_user,
             recipient=profile_user,
-            verb=_("followed you"),
+            verb=gettext_noop("followed you"),
             action_object=current_user,
             notification_type="new_follower",
         )

--- a/langcorrect/posts/api/views.py
+++ b/langcorrect/posts/api/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404, render
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from notifications.signals import notify
 from rest_framework import generics, status
 from rest_framework.response import Response
@@ -28,7 +28,7 @@ class PostReplyCreateUpdateAPIView(generics.GenericAPIView):
             notify.send(
                 sender=reply_author,
                 recipient=list(recipients),
-                verb=_("replied on"),
+                verb=gettext_noop("replied on"),
                 action_object=post,
                 notification_type="new_reply",
             )

--- a/langcorrect/posts/models.py
+++ b/langcorrect/posts/models.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from model_utils.models import SoftDeletableModel, TimeStampedModel
 from notifications.signals import notify
 from taggit.managers import TaggableManager
@@ -125,7 +126,7 @@ def send_follower_notifications(sender, instance, created, **kwargs):
         notify.send(
             sender=user,
             recipient=recipients,
-            verb=_("submitted a new entry"),
+            verb=gettext_noop("submitted a new entry"),
             action_object=post,
             notification_type="new_post",
         )


### PR DESCRIPTION
closes #191 

For all of these notification types, we should add translation. I considered it another task. This will fix the current bug and if we correct the translation files it will be fine.