### PR TITLE
Show only logged-in user's notifications

### DIFF
--- a/langcorrect/templates/base.html
+++ b/langcorrect/templates/base.html
@@ -106,7 +106,9 @@
     {% include "footer.html" %}
     <!-- /container -->
     {% block modal %}
-      {% include "modals/notifications.html" %}
+      {% if request.user.is_authenticated %}
+        {% include "modals/notifications.html" %}
+      {% endif %}
     {% endblock modal %}
     {% block inline_javascript %}
       {% comment %}

--- a/langcorrect/templates/modals/notifications.html
+++ b/langcorrect/templates/modals/notifications.html
@@ -16,7 +16,7 @@
       </div>
       <div class="modal-body">
         <div class="list-group list-group-flush">
-          {% for notification in user.notifications.unread %}
+          {% for notification in request.user.notifications.unread %}
             <a href="{% url 'notifications:mark_as_read' notification.slug %}?next={{ notification.action_object.get_absolute_url }}"
                class="list-group-item list-group-item-action unread-notification">
               <div class="row d-flex align-items-center py-2">


### PR DESCRIPTION
closes #196 

The user object was previously overwritten, displaying the profile user's notifications instead of the logged-in user's.