### PR TITLE
Add Tests for PostListView

### DIFF
--- a/langcorrect/languages/tests.py
+++ b/langcorrect/languages/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase  # noqa: F401
-
-# Create your tests here.

--- a/langcorrect/languages/tests/factories.py
+++ b/langcorrect/languages/tests/factories.py
@@ -1,0 +1,13 @@
+from factory import Sequence
+from factory.django import DjangoModelFactory
+
+from langcorrect.languages.models import Language
+
+
+class LanguageFactory(DjangoModelFactory):
+    en_name = Sequence(lambda n: f"language{n}")
+    code = Sequence(lambda n: f"code{n}")
+
+    class Meta:
+        model = Language
+        django_get_or_create = ("en_name", "code")

--- a/langcorrect/posts/tests/factories.py
+++ b/langcorrect/posts/tests/factories.py
@@ -1,0 +1,18 @@
+from factory import Faker, SubFactory
+from factory.django import DjangoModelFactory
+
+from langcorrect.languages.tests.factories import LanguageFactory
+from langcorrect.posts.models import Post, PostVisibility
+from langcorrect.users.tests.factories import UserFactory
+
+
+class PostFactory(DjangoModelFactory):
+    slug = Faker("uuid4")
+    user = SubFactory(UserFactory)
+    permission = Faker("random_element", elements=[elem.value for elem in PostVisibility])
+    is_corrected = Faker("random_element", elements=[0, 1])
+    language = SubFactory(LanguageFactory)
+
+    class Meta:
+        model = Post
+        django_get_or_create = ["slug"]

--- a/langcorrect/posts/tests/test_views.py
+++ b/langcorrect/posts/tests/test_views.py
@@ -1,8 +1,13 @@
+from urllib.parse import urlencode
+
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from langcorrect.contributions.models import Contribution
 from langcorrect.languages.models import Language, LanguageLevel, LevelChoices
+from langcorrect.languages.tests.factories import LanguageFactory
+from langcorrect.posts.models import Post, PostVisibility
+from langcorrect.posts.tests.factories import PostFactory
 from langcorrect.posts.views import PostCreateView
 from langcorrect.users.tests.factories import UserFactory
 
@@ -35,3 +40,75 @@ class TestPostCreateView(TestCase):
         self.user.refresh_from_db()
         contribution = Contribution.objects.get(user=self.user)
         assert contribution.writing_streak == 1
+
+
+class TestPostListView(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.languages = LanguageFactory.create_batch(2)
+        PostFactory.create_batch(25, language=cls.languages[0])
+        PostFactory.create_batch(25, language=cls.languages[1])
+        cls.user = UserFactory()
+        LanguageLevel.objects.create(user=cls.user, language=cls.languages[0], level=LevelChoices.NATIVE)
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_anon_queryset(self):
+        """
+        Test if qs for anon users returns only posts that are both public and corrected
+        """
+        response = self.client.get(reverse("posts:list"))
+        posts = response.context["object_list"]
+        expected_posts = Post.available_objects.filter(permission=PostVisibility.PUBLIC, is_corrected=1)
+        self.assertQuerySetEqual(posts, expected_posts)
+
+    def test_auth_queryset(self):
+        """
+        Test if qs for auth users returns only posts that are written in their native language
+        """
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("posts:list"))
+        posts = response.context["object_list"]
+        expected_posts = Post.objects.filter(language=self.languages[0])
+        self.assertQuerySetEqual(posts, expected_posts)
+
+    def test_anon_user_redirected(self):
+        """
+        Test if anon users are redirecting in learn and following modes
+        """
+        params1 = {"mode": "learn"}
+        url1 = f"{reverse('posts:list')}?{urlencode(params1)}"
+        response1 = self.client.get(url1)
+        expected_url1 = f"{reverse('account_login')}?next={url1}"
+        self.assertRedirects(response1, expected_url1)
+
+        params2 = {"mode": "following"}
+        url2 = f"{reverse('posts:list')}?{urlencode(params2)}"
+        response2 = self.client.get(url2)
+        expected_url2 = f"{reverse('account_login')}?next={url2}"
+        self.assertRedirects(response2, expected_url2)
+
+    def test_auth_user_not_redirected(self):
+        """
+        Test if auth users are not redirected in learn and following modes
+        """
+        self.client.force_login(self.user)
+        params1 = {"mode": "following"}
+        url1 = f"{reverse('posts:list')}?{urlencode(params1)}"
+        response1 = self.client.get(url1)
+        self.assertEqual(response1.status_code, 200)
+
+        params2 = {"mode": "learn"}
+        url2 = f"{reverse('posts:list')}?{urlencode(params2)}"
+        response2 = self.client.get(url2)
+        self.assertEqual(response2.status_code, 200)
+
+    def test_filter_queryset_by_lang_code(self):
+        self.client.force_login(self.user)
+        params = {"lang_code": self.languages[0].code}
+        url = f"{reverse('posts:list')}?{urlencode(params)}"
+        response = self.client.get(url)
+        posts = response.context["object_list"]
+        expected_posts = Post.available_objects.filter(language=self.languages[0])
+        self.assertQuerySetEqual(posts, expected_posts)


### PR DESCRIPTION
This PR adds a couple of tests for PostListView.

Changes:
- Added qs tests for anonymous and authenticated users
- Added redirect tests when accessing `learn` and `following` mode for anonymous and authenticated users
- Added qs tests for filtering by language

Results:

All new tests pass, raising the coverage to 75%.