### PR TITLE
Fix chinese sentences not splitting correctly (#249)

### DIFF
--- a/langcorrect/posts/utils.py
+++ b/langcorrect/posts/utils.py
@@ -91,6 +91,6 @@ class SentenceSplitter:
             return self._split_sentences_using_nltk(text, lang_name)
         elif lang_code == "ja":
             return self._split_sentences_japanese(text)
-        elif lang_code == "zh":
+        elif lang_code in ["zh-hans", "zh-hant"]:
             return self._split_sentences_chinese(text)
         return self._split_sentences_generic(text)


### PR DESCRIPTION
closes #249 

This PR fixes an issue where traditional and simplified variants were not correctly processed and split due to a mismatch in language codes.