### PR TITLE
Revert "Fix popup menu overlap (#298)"

### DIFF
--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -7,7 +7,7 @@
   {{ post.title }}
 {% endblock title %}
 {% block content %}
-  <div class="sticky-top py-2 bg-white shadow-sm mb-3 z-n1">
+  <div class="sticky-top py-2 bg-white shadow-sm mb-3">
     <div class="container">
       <div class="d-flex justify-content-between align-items-center">
         <div class="d-flex gap-3">


### PR DESCRIPTION
Reverts LangCorrect/server#300

Reverting because the modal button became unclickable.