### PR TITLE
141 convert prompt to journal

### DIFF
--- a/langcorrect/prompts/templatetags/prompt_tags.py
+++ b/langcorrect/prompts/templatetags/prompt_tags.py
@@ -4,13 +4,9 @@ register = template.Library()
 
 
 @register.inclusion_tag("prompts/partials/prompt_card.html")
-def render_prompt_card(instance):
+def render_prompt_card(instance, current_user):
     user = instance.user
     created = instance.created
     prompt = instance
 
-    return {
-        "user": user,
-        "created": created,
-        "prompt": prompt,
-    }
+    return {"user": user, "created": created, "prompt": prompt, "current_user": current_user}

--- a/langcorrect/prompts/urls.py
+++ b/langcorrect/prompts/urls.py
@@ -1,10 +1,16 @@
 from django.urls import path
 
-from langcorrect.prompts.views import prompt_create_view, prompt_detail_view, prompt_list_view
+from langcorrect.prompts.views import (
+    convert_prompt_to_journal_entry,
+    prompt_create_view,
+    prompt_detail_view,
+    prompt_list_view,
+)
 
 app_name = "prompts"
 urlpatterns = [
     path("", view=prompt_list_view, name="list"),
     path("~create/", view=prompt_create_view, name="create"),
     path("<str:slug>/", view=prompt_detail_view, name="detail"),
+    path("convert_to_journal/<str:slug>/", convert_prompt_to_journal_entry, name="convert_to_journal"),
 ]

--- a/langcorrect/templates/prompts/partials/prompt_card.html
+++ b/langcorrect/templates/prompts/partials/prompt_card.html
@@ -22,12 +22,29 @@
           </span>
         </div>
       </div>
-      <a a
-         href="{% url 'posts:create-prompt-based-post' prompt.slug %}"
-         class="btn btn-sm btn-outline-primary">
-        <i class="fa-solid fa-reply"></i>
-        {% translate "Respond" %}
-      </a>
+      <div>
+        <a href="{% url 'posts:create-prompt-based-post' prompt.slug %}"
+           class="btn btn-sm btn-outline-primary">
+          <i class="fa-solid fa-reply"></i>
+          {% translate "Respond" %}
+        </a>
+        {% if current_user.is_staff or current_user.is_moderator %}
+          <div class="btn-group">
+            <button type="button"
+                    class="btn btn-sm btn-danger dropdown-toggle"
+                    data-bs-toggle="dropdown"
+                    aria-expanded="false">
+              <i class="fa-solid fa-screwdriver-wrench"></i>
+            </button>
+            <ul class="dropdown-menu">
+              <li>
+                <a class="dropdown-item"
+                   href="{% url 'prompts:convert_to_journal' prompt.slug %}">Convert to journal entry</a>
+              </li>
+            </ul>
+          </div>
+        {% endif %}
+      </div>
     </div>
   </div>
 </div>

--- a/langcorrect/templates/prompts/prompt_list.html
+++ b/langcorrect/templates/prompts/prompt_list.html
@@ -10,6 +10,18 @@
   {% translate "Prompts" %} · LangCorrect
 {% endblock title %}
 {% block content %}
+  <div class="alert alert-info" role="alert">
+    This space is designed exclusively for generating and sharing creative writing prompts. Please refrain from posting content unrelated to writing prompts.
+    <br />
+    <br />
+    このスペースは、クリエイティブなライティングプロンプトの生成と共有のために特別に設計されています。ライティングプロンプトに関係のない内容の投稿はご遠慮ください。
+    <br />
+    <br />
+    本区域专为创作和分享创意写作提示而设计。请勿发布与写作提示无关的内容。
+    <br />
+    <br />
+    이 공간은 창의적인 글쓰기 프롬프트를 생성하고 공유하기 위해 특별히 설계되었습니다. 글쓰기 프롬프트와 관련 없는 내용 게시는 삼가해 주시기 바랍니다.
+  </div>
   <div class="row">
     <div class="col-12">
       <div class="d-flex justify-content-end mb-3">

--- a/langcorrect/templates/prompts/prompt_list.html
+++ b/langcorrect/templates/prompts/prompt_list.html
@@ -44,7 +44,7 @@
       </div>
       <div class="d-grid gap-3">
         {% for prompt in object_list %}
-          {% render_prompt_card instance=prompt %}
+          {% render_prompt_card instance=prompt current_user=request.user %}
         {% endfor %}
         {% include "pagination.html" %}
       </div>


### PR DESCRIPTION
closes #141 
closes #326

Adds a utility to convert prompts to journal entries and includes a static banner informing users that prompts should not be used to create journal entries.