### PR TITLE
Use display_name instead of username

### DIFF
--- a/langcorrect/templates/contributions/partials/contribution.html
+++ b/langcorrect/templates/contributions/partials/contribution.html
@@ -4,7 +4,7 @@
   <th scope="row">{{ contribution.rank }}</th>
   <td>
     <a class="text-decoration-none {% if contribution.user.is_premium_user %}text-premium{% endif %}"
-       href="{{ contribution.user.get_absolute_url }}">{{ contribution.user.username }}</a>
+       href="{{ contribution.user.get_absolute_url }}">{{ contribution.user.display_name }}</a>
     <br />
     <small class="text-muted">
       {% blocktrans with year=contribution.user.date_joined|date:"Y" %}

--- a/langcorrect/templates/emails/new_correction.html
+++ b/langcorrect/templates/emails/new_correction.html
@@ -4,7 +4,7 @@
   <table>
     <tr>
       <th>
-        <h2>Hi, {{ display_name }}</h2>
+        <h2>Hi, {{ username }}</h2>
         <p>
           Great news! A native speaker has taken the time to review and correct your recent journal entry. This is an excellent chance for you to learn from your mistakes and make improvements in your language skills.
         </p>

--- a/langcorrect/templates/emails/new_correction.html
+++ b/langcorrect/templates/emails/new_correction.html
@@ -4,7 +4,7 @@
   <table>
     <tr>
       <th>
-        <h2>Hi, {{ username }}</h2>
+        <h2>Hi, {{ display_name }}</h2>
         <p>
           Great news! A native speaker has taken the time to review and correct your recent journal entry. This is an excellent chance for you to learn from your mistakes and make improvements in your language skills.
         </p>

--- a/langcorrect/templates/follows/follower_list.html
+++ b/langcorrect/templates/follows/follower_list.html
@@ -16,7 +16,7 @@
              href="{{ follower.user.get_absolute_url }}">
             <div class="d-flex align-items-center gap-2">
               <img src="{{ follower.user.avatar }}" alt="profile" />
-              {{ follower.user.username }}
+              {{ follower.user.display_name }}
             </div>
           </a>
         </li>

--- a/langcorrect/templates/follows/following_list.html
+++ b/langcorrect/templates/follows/following_list.html
@@ -16,7 +16,7 @@
              href="{{ follower.follow_to.get_absolute_url }}">
             <div class="d-flex align-items-center gap-2">
               <img src="{{ follower.follow_to.avatar }}" alt="profile" />
-              {{ follower.follow_to.username }}
+              {{ follower.follow_to.display_name }}
             </div>
           </a>
         </li>

--- a/langcorrect/templates/navbar.html
+++ b/langcorrect/templates/navbar.html
@@ -97,7 +97,7 @@
                   <img src="{{ request.user.avatar }}" alt="profile" height="38" />
                   <div class="ms-3">
                     <p class="mb-0 {% if request.user.is_premium_user %}text-premium{% else %}text-muted{% endif %}">
-                      <strong>{{ request.user.username }}</strong>
+                      <strong>{{ request.user.display_name }}</strong>
                     </p>
                     <p class="mb-0 text-muted">
                       <small>{{ request.user.email }}</small>
@@ -163,7 +163,7 @@
               title="{% translate 'Visit your profile' %}">
             <i class="fas fa-user fa-fw"></i>
             <a href="{% url 'users:detail' request.user.username %}"
-               class="text-decoration-none text-white">{{ request.user.username }}</a>
+               class="text-decoration-none text-white">{{ request.user.display_name }}</a>
           </li>
           <li class="list-inline-item"
               data-bs-toggle="tooltip"

--- a/langcorrect/templates/pages/checkout_canceled.html
+++ b/langcorrect/templates/pages/checkout_canceled.html
@@ -5,7 +5,7 @@
     <div class="card-header bg-transparent">Checkout Canceled!</div>
     <div class="card-body">
       <p>
-        Hi, <strong>{{ request.user.username }}</strong>
+        Hi, <strong>{{ request.user.display_name }}</strong>
       </p>
       <p>We noticed you canceled your checkout process. Rest assured, you have not been charged.</p>
       <hr />

--- a/langcorrect/templates/pages/checkout_success.html
+++ b/langcorrect/templates/pages/checkout_success.html
@@ -5,7 +5,7 @@
     <div class="card-header bg-transparent">Payment successful!</div>
     <div class="card-body">
       <p>
-        Thank you for your purchase, <strong>{{ request.user.username }}</strong>!
+        Thank you for your purchase, <strong>{{ request.user.display_name }}</strong>!
       </p>
       <p>
         Your premium features are now unlocked. To view or manage your subscription, visit <a href="{% url 'subscriptions:manage-subscription' %}">Manage Subscription</a>.

--- a/langcorrect/templates/users/user_form.html
+++ b/langcorrect/templates/users/user_form.html
@@ -3,10 +3,10 @@
 {% load crispy_forms_tags %}
 
 {% block title %}
-  {{ user.username }}
+  {{ user.display_name }}
 {% endblock title %}
 {% block content %}
-  <h1>{{ user.username }}</h1>
+  <h1>{{ user.display_name }}</h1>
   <form class="form-horizontal"
         method="post"
         action="{% url 'users:update' %}">

--- a/langcorrect/utils/mailing.py
+++ b/langcorrect/utils/mailing.py
@@ -61,7 +61,7 @@ def email_new_correction(post):
     email = user.email
     subject = "[LangCorrect] New Correction!"
 
-    context = {"username": user.username, "post_link": f"{settings.SITE_BASE_URL}{post.get_absolute_url()}"}
+    context = {"username": user.display_name, "post_link": f"{settings.SITE_BASE_URL}{post.get_absolute_url()}"}
 
     msg = EmailSender()
     msg.send_email(


### PR DESCRIPTION
closes #308

All relevant UI data points have been changed to use `display_name`.

A subsequent PR should correct the `display_name` function to use first/last name - or allow the user to modify `nickname`.