### PR TITLE
358 Don't show a completed prompt if the response has been removed 

### DIFF
--- a/langcorrect/prompts/views.py
+++ b/langcorrect/prompts/views.py
@@ -33,7 +33,7 @@ class PromptListView(LoginRequiredMixin, ListView):
         lang_code = self.get_lang_code()
 
         if mode == "completed":
-            qs = qs.filter(post__user=current_user)
+            qs = qs.filter(post__user=current_user, post__is_removed=False)
         else:
             qs = qs.exclude(post__user=current_user)
 

--- a/langcorrect/templates/no_content_card.html
+++ b/langcorrect/templates/no_content_card.html
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
+        <p class="card-text">{{ message }}</p>
+        <a href="{{ link }}" class="btn btn-primary">{{ btn_message }}</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/langcorrect/templates/prompts/prompt_list.html
+++ b/langcorrect/templates/prompts/prompt_list.html
@@ -55,10 +55,24 @@
         </div>
       </div>
       <div class="d-grid gap-3">
-        {% for prompt in object_list %}
-          {% render_prompt_card instance=prompt current_user=request.user %}
-        {% endfor %}
-        {% include "pagination.html" %}
+        {% if object_list or mode == "open" %}
+          {% for prompt in object_list %}
+            {% render_prompt_card instance=prompt current_user=request.user %}
+          {% endfor %}
+          {% include "pagination.html" %}
+        {% else %}
+          <div class="row">
+            <div class="col">
+              <div class="card">
+                <div class="card-body">
+                  <h5 class="card-title">Uh oh</h5>
+                  <p class="card-text">You haven't responded to any prompts.</p>
+                  <a href="{% url 'prompts:list' %}" class="btn btn-primary">Browse writing prompts</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% endif %}
       </div>
     </div>
     <!-- <div class="col-lg-4"> -->

--- a/langcorrect/templates/prompts/prompt_list.html
+++ b/langcorrect/templates/prompts/prompt_list.html
@@ -61,24 +61,11 @@
           {% endfor %}
           {% include "pagination.html" %}
         {% else %}
-          <div class="row">
-            <div class="col">
-              <div class="card">
-                <div class="card-body">
-                  <h5 class="card-title">Uh oh</h5>
-                  <p class="card-text">You haven't responded to any prompts.</p>
-                  <a href="{% url 'prompts:list' %}" class="btn btn-primary">Browse writing prompts</a>
-                </div>
-              </div>
-            </div>
-          </div>
+          {% url 'prompts:list' as button_url %}
+          {% include "no_content_card.html" with message="You haven't responded to any prompts." btn_message="Browse writing prompts" link=button_url %}
         {% endif %}
       </div>
     </div>
-    <!-- <div class="col-lg-4"> -->
-    <!-- <div class="card">
-      </div> -->
-    <!-- </div> -->
   </div>
 {% endblock content %}
 {% block inline_javascript %}


### PR DESCRIPTION
closes #358 

I've also created a card that we can hopefully reuse in other places where there's no content, in place of the empty table we're showing now.

<img width="1331" alt="image" src="https://github.com/LangCorrect/server/assets/102985900/264a1182-aeb6-4327-afe1-47dbd981af0e">

To pass in a reversed url into Django's `include`, the best solution that I was able to find was to assign the link to a variable. Please lmk if there's a better way to handle this!