### PR TITLE
372 refactor split post signal

### DIFF
--- a/langcorrect/posts/forms.py
+++ b/langcorrect/posts/forms.py
@@ -24,11 +24,12 @@ class CustomPostForm(forms.ModelForm):
             self.fields["image"].disabled = True
 
     def clean_text(self):
-        text = self.cleaned_data["text"]
+        text = self.cleaned_data["text"].strip()
+
         if text and len(text) < 50:
             msg = _(f"You need to write {50 - len(text)} more characters to meet the minimum requirement.")
             raise forms.ValidationError(msg)
-        return self.cleaned_data["text"]
+        return text
 
     def clean_tags(self):
         tags = self.cleaned_data.get("tags", None)

--- a/langcorrect/posts/helpers.py
+++ b/langcorrect/posts/helpers.py
@@ -47,13 +47,14 @@ def check_can_create_post(user):
     return False
 
 
-def hide_old_post_rows_on_edit(post):
-    """
-    Hides all rows associated with a given post when it is edited.
-    """
-    from langcorrect.posts.models import PostRow  # pylint: disable=import-outside-toplevel
+# TODO: Remove this
+# def hide_old_post_rows_on_edit(post):
+#     """
+#     Hides all rows associated with a given post when it is edited.
+#     """
+#     from langcorrect.posts.models import PostRow  # pylint: disable=import-outside-toplevel
 
-    PostRow.objects.filter(post=post).update(is_actual=False)
+#     PostRow.objects.filter(post=post).update(is_actual=False)
 
 
 def set_post_row_active(post_row, order):

--- a/langcorrect/posts/helpers.py
+++ b/langcorrect/posts/helpers.py
@@ -1,15 +1,9 @@
-"""
-NOTE: This file uses local imports within certain functions to resolve circular
-dependency issues. If there are suggestions to better handle these dependencies,
-further review and refactoring are welcomed.
-"""
-
 from django.conf import settings
+
+from langcorrect.posts.models import Post
 
 
 def get_post_counts_by_language(languages, corrected=False):
-    from langcorrect.posts.models import Post  # pylint: disable=import-outside-toplevel
-
     data = {}
 
     for language in languages:
@@ -45,22 +39,3 @@ def check_can_create_post(user):
     elif not has_uncorrected_posts:
         return True
     return False
-
-
-# TODO: Remove this
-# def hide_old_post_rows_on_edit(post):
-#     """
-#     Hides all rows associated with a given post when it is edited.
-#     """
-#     from langcorrect.posts.models import PostRow  # pylint: disable=import-outside-toplevel
-
-#     PostRow.objects.filter(post=post).update(is_actual=False)
-
-
-def set_post_row_active(post_row, order):
-    """
-    Sets the specified post row to active and updates its order.
-    """
-    post_row.is_actual = True
-    post_row.order = order
-    post_row.save()

--- a/langcorrect/posts/tests/test_views.py
+++ b/langcorrect/posts/tests/test_views.py
@@ -206,9 +206,6 @@ class TestPostUpdateView(TestCase):
         hidden_rows_count = PostRow.available_objects.filter(post=self.post, is_actual=False).count()
         self.assertEqual(1, hidden_rows_count)
 
-    # # def test_foo(self):
-    # #     breakpoint()
-
 
 class TestPostListView(TestCase):
     fixtures = ["fixtures/tests/languages.json"]

--- a/langcorrect/posts/utils.py
+++ b/langcorrect/posts/utils.py
@@ -86,6 +86,7 @@ class SentenceSplitter:
         return sent_tokenize(text, language=language)
 
     def split_sentences(self, text, lang_code):
+        text = text.strip()
         if lang_code in self.nltk_supported_languages:
             lang_name = self.nltk_lang_map.get(lang_code)
             return self._split_sentences_using_nltk(text, lang_name)

--- a/langcorrect/posts/views.py
+++ b/langcorrect/posts/views.py
@@ -14,10 +14,7 @@ from langcorrect.corrections.helpers import get_popular_correctors, populate_use
 from langcorrect.corrections.models import CorrectedRow, OverallFeedback, PerfectRow
 from langcorrect.languages.models import LanguageLevel
 from langcorrect.posts.forms import CustomPostForm
-from langcorrect.posts.helpers import (  # , hide_old_post_rows_on_edit
-    check_can_create_post,
-    get_post_counts_by_language,
-)
+from langcorrect.posts.helpers import check_can_create_post, get_post_counts_by_language
 from langcorrect.posts.models import Post, PostImage, PostReply, PostVisibility
 from langcorrect.prompts.models import Prompt
 from langcorrect.users.models import User
@@ -176,11 +173,6 @@ class PostUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context["is_edit"] = True
         return context
-
-    # def form_valid(self, form):
-    #     post = self.get_object()
-    #     hide_old_post_rows_on_edit(post)
-    #     return super().form_valid(form)
 
 
 post_update_view = PostUpdateView.as_view()

--- a/langcorrect/posts/views.py
+++ b/langcorrect/posts/views.py
@@ -14,7 +14,10 @@ from langcorrect.corrections.helpers import get_popular_correctors, populate_use
 from langcorrect.corrections.models import CorrectedRow, OverallFeedback, PerfectRow
 from langcorrect.languages.models import LanguageLevel
 from langcorrect.posts.forms import CustomPostForm
-from langcorrect.posts.helpers import check_can_create_post, get_post_counts_by_language, hide_old_post_rows_on_edit
+from langcorrect.posts.helpers import (  # , hide_old_post_rows_on_edit
+    check_can_create_post,
+    get_post_counts_by_language,
+)
 from langcorrect.posts.models import Post, PostImage, PostReply, PostVisibility
 from langcorrect.prompts.models import Prompt
 from langcorrect.users.models import User
@@ -174,10 +177,10 @@ class PostUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         context["is_edit"] = True
         return context
 
-    def form_valid(self, form):
-        post = self.get_object()
-        hide_old_post_rows_on_edit(post)
-        return super().form_valid(form)
+    # def form_valid(self, form):
+    #     post = self.get_object()
+    #     hide_old_post_rows_on_edit(post)
+    #     return super().form_valid(form)
 
 
 post_update_view = PostUpdateView.as_view()


### PR DESCRIPTION
Refactors hotfix #371 

**Post Form**
- While testing `TestPostUpdateView`, I ran into issues where sentences were not being split correctly because due to normalization issues (IE: white space). I fixed this by making sure white space was stripped in our post form and in `SentenceSplitter`.

**Split Post Signal**
- I refactored it so that it is more readable. It will now accurately keep track of sentence ordering. I ended up using a dict to search for memberships for faster lookup.