### PR TITLE
Fix language level assignment in PostCreateView (#391)

### DIFF
--- a/langcorrect/posts/views.py
+++ b/langcorrect/posts/views.py
@@ -212,7 +212,7 @@ class PostCreateView(LoginRequiredMixin, SuccessMessageMixin, CreateView):
             form.instance.prompt = prompt
 
         language_level = LanguageLevel.objects.get(user=current_user, language=form.instance.language)
-        form.instance.language_level = language_level
+        form.instance.language_level = language_level.level
 
         self.object = form.save()
         image_obj = self.request.FILES.get("image", None)


### PR DESCRIPTION
fixes #391 

Temp fix. We should use choices from LevelChoices instead of assigning the level directly.