### PR TITLE
245 Image Attachment Improvements

### DIFF
--- a/langcorrect/posts/forms.py
+++ b/langcorrect/posts/forms.py
@@ -23,6 +23,8 @@ class CustomPostForm(forms.ModelForm):
         if not self.user.is_premium_user:
             self.fields["image"].disabled = True
             self.fields["image"].label = "Image (Premium Feature)"
+        else:
+            self.fields["image"].label = "Image (JPEG, JPG, <5MB)"
 
     def clean_text(self):
         text = self.cleaned_data["text"].strip()

--- a/langcorrect/posts/forms.py
+++ b/langcorrect/posts/forms.py
@@ -22,6 +22,7 @@ class CustomPostForm(forms.ModelForm):
             self.fields["text"].disabled = True
         if not self.user.is_premium_user:
             self.fields["image"].disabled = True
+            self.fields["image"].label = "Image (Premium Feature)"
 
     def clean_text(self):
         text = self.cleaned_data["text"].strip()

--- a/langcorrect/posts/templatetags/post_tags.py
+++ b/langcorrect/posts/templatetags/post_tags.py
@@ -4,14 +4,7 @@ register = template.Library()
 
 
 @register.inclusion_tag("posts/partials/post_card.html")
-def render_post_card(
-    instance,
-    current_user,
-    correctors,
-    disable_native_text=False,
-    disable_stretched_link=False,
-    disable_text_truncation=False,
-):
+def render_post_card(instance, current_user, correctors, is_detailed_view=False):
     user = instance.user
     created = instance.created
     post = instance
@@ -27,9 +20,7 @@ def render_post_card(
         "current_user": current_user,
         "already_corrected": already_corrected,
         "post": post,
-        "disable_stretched_link": disable_stretched_link,
-        "disable_text_truncation": disable_text_truncation,
-        "disable_native_text": disable_native_text,
+        "is_detailed_view": is_detailed_view,
     }
 
 

--- a/langcorrect/templates/posts/partials/card_footer.html
+++ b/langcorrect/templates/posts/partials/card_footer.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+{% load humanize %}
+
+<div class="card-footer bg-transparent">
+  <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex gap-2">
+      <div class="d-flex align-items-center gap-1">
+        <span class="chip"
+              data-bs-toggle="tooltip"
+              data-bs-placement="bottom"
+              data-bs-title="{{ post.language }}">
+          <i class="fa-solid fa-globe pe-1"></i>  {{ post.language.code }}
+        </span>
+        <span class="chip"
+              data-bs-toggle="tooltip"
+              data-bs-placement="bottom"
+              data-bs-title="{% translate 'Correctors' %}">
+          <i class="fa-regular fa-circle-check pe-1"></i> {{ post.corrected_by_count }}
+        </span>
+      </div>
+    </div>
+    {% if current_user.id == user.id %}
+      <div>
+        <a href="{% url 'posts:delete' post.slug %}"
+           class="btn btn-sm btn-outline-danger">{% translate "Delete" %}</a>
+        <a href="{% url 'posts:update' post.slug %}"
+           class="btn btn-sm btn-outline-secondary">{% translate "Edit" %}</a>
+      </div>
+    {% elif post.language not in current_user.native_languages %}
+      <div data-bs-toggle="tooltip"
+           data-bs-placement="bottom"
+           data-bs-title="{% translate "You can only correct entries in your native language(s)" %}">
+        <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
+          <i class="fa-solid fa-ban"></i>
+          {% translate "Correct" %}
+        </button>
+      </div>
+    {% else %}
+      <a href="{% url 'posts:make-corrections' post.slug %}"
+         class="btn btn-sm {% if already_corrected %} btn-primary {% else %} btn-outline-primary {% endif %}">
+        <i class="fa-regular fa-circle-check"></i>
+        {% if already_corrected %}
+          {% translate "Corrected" %}
+        {% else %}
+          {% translate "Correct" %}
+        {% endif %}
+      </a>
+    {% endif %}
+  </div>
+</div>

--- a/langcorrect/templates/posts/partials/card_header.html
+++ b/langcorrect/templates/posts/partials/card_header.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 
 <div class="card-header bg-transparent">
-  <div class="d-flex align-items-center justify-content-between">
+  <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
     <div class="d-flex align-items-center gap-3">
       <a href="{{ user.get_absolute_url }}">
         <img src="{{ user.avatar }}" alt="{{ user.display_name }}'s avatar" />

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -35,8 +35,8 @@
         <div class="{% if disable_native_text %} col-md-6 col-12 {% else %} col-12 {% endif %} my-auto">
           {% if post.postimage_set.all %}
             <div class="container p-0">
-              <div class="row justify-content-center align-items-center py-3">
-                <div class="col">
+              <div class="row justify-content-start align-items-center py-3">
+                <div class="col {% if disable_native_text %} col-12 {% else %} col-md-6 {% endif %}">
                   {% for image in post.postimage_set.all %}
                     <img src="{{ image.get_image_url }}"
                          class="img-fluid pointer js-lightbox-img rounded"

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -4,7 +4,7 @@
 <div class="card">
   {% include "posts/partials/card_header.html" %}
   <div class="card-body {% if not disable_stretched_link %}hoverable{% endif %}">
-    <div class="container p-0">
+    <div class="position-relative container p-0">
       <div class="row">
         <!-- Prompt col -->
         {% if post.prompt %}

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -26,6 +26,18 @@
         <a href="{{ post.get_absolute_url }}"
            class="stretched-link link-secondary"></a>
       {% endif %}
+      {% if post.postimage_set.all %}
+        <div class="container row py-3">
+          <div class="col col-md-6 p-0">
+            {% for image in post.postimage_set.all %}
+              <img src="{{ image.get_image_url }}"
+                   class="img-fluid pointer js-lightbox-img"
+                   alt="image"
+                   data-img-src="{{ image.get_image_url }}" />
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
   <div class="card-footer bg-transparent">

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -51,52 +51,5 @@
       </div>
     </div>
   </div>
-  <!-- Card footer -->
-  <div class="card-footer bg-transparent">
-    <div class="d-flex justify-content-between align-items-center">
-      <div class="d-flex gap-2">
-        <div class="d-flex align-items-center gap-1">
-          <span class="chip"
-                data-bs-toggle="tooltip"
-                data-bs-placement="bottom"
-                data-bs-title="{{ post.language }}">
-            <i class="fa-solid fa-globe pe-1"></i>  {{ post.language.code }}
-          </span>
-          <span class="chip"
-                data-bs-toggle="tooltip"
-                data-bs-placement="bottom"
-                data-bs-title="{% translate 'Correctors' %}">
-            <i class="fa-regular fa-circle-check pe-1"></i> {{ post.corrected_by_count }}
-          </span>
-        </div>
-      </div>
-      {% if current_user.id == user.id %}
-        <div>
-          <a href="{% url 'posts:delete' post.slug %}"
-             class="btn btn-sm btn-outline-danger">{% translate "Delete" %}</a>
-          <a href="{% url 'posts:update' post.slug %}"
-             class="btn btn-sm btn-outline-secondary">{% translate "Edit" %}</a>
-        </div>
-      {% elif post.language not in current_user.native_languages %}
-        <div data-bs-toggle="tooltip"
-             data-bs-placement="bottom"
-             data-bs-title="{% translate "You can only correct entries in your native language(s)" %}">
-          <button type="button" class="btn btn-sm btn-outline-secondary" disabled>
-            <i class="fa-solid fa-ban"></i>
-            {% translate "Correct" %}
-          </button>
-        </div>
-      {% else %}
-        <a href="{% url 'posts:make-corrections' post.slug %}"
-           class="btn btn-sm {% if already_corrected %} btn-primary {% else %} btn-outline-primary {% endif %}">
-          <i class="fa-regular fa-circle-check"></i>
-          {% if already_corrected %}
-            {% translate "Corrected" %}
-          {% else %}
-            {% translate "Correct" %}
-          {% endif %}
-        </a>
-      {% endif %}
-    </div>
-  </div>
+  {% include "posts/partials/card_footer.html" %}
 </div>

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -4,17 +4,19 @@
 <div class="card">
   {% include "posts/partials/card_header.html" %}
   <div class="card-body {% if not disable_stretched_link %}hoverable{% endif %}">
-    <div class="position-relative">
-      <div class="container row">
+    <div class="container p-0">
+      <div class="row">
+        <!-- Prompt col -->
+        {% if post.prompt %}
+          <div class="col-12 border-start border-2 px-2 mb-2">
+            <a href="{{ post.prompt.get_absolute_url }}"
+               class="link-secondary text-decoration-none">
+              <i class="fa-solid fa-signature pe-1"></i>
+            {{ post.prompt.content }}</a>
+          </div>
+        {% endif %}
+        <!-- Text col -->
         <div class="{% if disable_native_text and post.postimage_set.all %} col-md-6 col-12 {% else %} col-12 {% endif %}">
-          {% if post.prompt %}
-            <div class="border-start border-2 px-2 mb-2">
-              <a href="{{ post.prompt.get_absolute_url }}"
-                 class="link-secondary text-decoration-none">
-                <i class="fa-solid fa-signature pe-1"></i>
-              {{ post.prompt.content }}</a>
-            </div>
-          {% endif %}
           <h5 lang="{{ post.language.code }}">{{ post.title }}</h5>
           <p lang="{{ post.language.code }}"
              class="mb-0 {% if not disable_text_truncation %}truncate-text line-clamp-10{% endif %}">
@@ -29,16 +31,19 @@
                class="stretched-link link-secondary"></a>
           {% endif %}
         </div>
-        <div class="{% if disable_native_text %} col-md-6 col-12 {% else %} col-12 {% endif %}">
+        <!-- Image col -->
+        <div class="{% if disable_native_text %} col-md-6 col-12 {% else %} col-12 {% endif %} my-auto">
           {% if post.postimage_set.all %}
-            <div class="container justify-content-center align-items-center row py-3">
-              <div class="col">
-                {% for image in post.postimage_set.all %}
-                  <img src="{{ image.get_image_url }}"
-                       class="img-fluid pointer js-lightbox-img rounded"
-                       alt="image"
-                       data-img-src="{{ image.get_image_url }}" />
-                {% endfor %}
+            <div class="container p-0">
+              <div class="row justify-content-center align-items-center py-3">
+                <div class="col">
+                  {% for image in post.postimage_set.all %}
+                    <img src="{{ image.get_image_url }}"
+                         class="img-fluid pointer js-lightbox-img rounded"
+                         alt="image"
+                         data-img-src="{{ image.get_image_url }}" />
+                  {% endfor %}
+                </div>
               </div>
             </div>
           {% endif %}
@@ -46,6 +51,7 @@
       </div>
     </div>
   </div>
+  <!-- Card footer -->
   <div class="card-footer bg-transparent">
     <div class="d-flex justify-content-between align-items-center">
       <div class="d-flex gap-2">

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -5,39 +5,45 @@
   {% include "posts/partials/card_header.html" %}
   <div class="card-body {% if not disable_stretched_link %}hoverable{% endif %}">
     <div class="position-relative">
-      {% if post.prompt %}
-        <div class="border-start border-2 px-2 mb-2">
-          <a href="{{ post.prompt.get_absolute_url }}"
-             class="link-secondary text-decoration-none">
-            <i class="fa-solid fa-signature pe-1"></i>
-          {{ post.prompt.content }}</a>
+      <div class="container row">
+        <div class="{% if disable_native_text and post.postimage_set.all %} col-md-6 col-12 {% else %} col-12 {% endif %}">
+          {% if post.prompt %}
+            <div class="border-start border-2 px-2 mb-2">
+              <a href="{{ post.prompt.get_absolute_url }}"
+                 class="link-secondary text-decoration-none">
+                <i class="fa-solid fa-signature pe-1"></i>
+              {{ post.prompt.content }}</a>
+            </div>
+          {% endif %}
+          <h5 lang="{{ post.language.code }}">{{ post.title }}</h5>
+          <p lang="{{ post.language.code }}"
+             class="mb-0 {% if not disable_text_truncation %}truncate-text line-clamp-10{% endif %}">
+            {{ post.text|linebreaksbr }}
+          </p>
+          {% if not disable_native_text and post.native_text %}
+            <hr class="text-muted" />
+            <p class="mt-3 text-muted">{{ post.native_text|linebreaksbr }}</p>
+          {% endif %}
+          {% if not disable_stretched_link %}
+            <a href="{{ post.get_absolute_url }}"
+               class="stretched-link link-secondary"></a>
+          {% endif %}
         </div>
-      {% endif %}
-      <h5 lang="{{ post.language.code }}">{{ post.title }}</h5>
-      <p lang="{{ post.language.code }}"
-         class="mb-0 {% if not disable_text_truncation %}truncate-text line-clamp-10{% endif %}">
-        {{ post.text|linebreaksbr }}
-      </p>
-      {% if not disable_native_text and post.native_text %}
-        <hr class="text-muted" />
-        <p class="mt-3 text-muted">{{ post.native_text|linebreaksbr }}</p>
-      {% endif %}
-      {% if not disable_stretched_link %}
-        <a href="{{ post.get_absolute_url }}"
-           class="stretched-link link-secondary"></a>
-      {% endif %}
-      {% if post.postimage_set.all %}
-        <div class="container row py-3">
-          <div class="col col-md-6 p-0">
-            {% for image in post.postimage_set.all %}
-              <img src="{{ image.get_image_url }}"
-                   class="img-fluid pointer js-lightbox-img"
-                   alt="image"
-                   data-img-src="{{ image.get_image_url }}" />
-            {% endfor %}
-          </div>
+        <div class="{% if disable_native_text %} col-md-6 col-12 {% else %} col-12 {% endif %}">
+          {% if post.postimage_set.all %}
+            <div class="container justify-content-center align-items-center row py-3">
+              <div class="col">
+                {% for image in post.postimage_set.all %}
+                  <img src="{{ image.get_image_url }}"
+                       class="img-fluid pointer js-lightbox-img rounded"
+                       alt="image"
+                       data-img-src="{{ image.get_image_url }}" />
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
         </div>
-      {% endif %}
+      </div>
     </div>
   </div>
   <div class="card-footer bg-transparent">

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -3,7 +3,7 @@
 
 <div class="card">
   {% include "posts/partials/card_header.html" %}
-  <div class="card-body {% if not disable_stretched_link %}hoverable{% endif %}">
+  <div class="card-body {% if not is_detailed_view %}hoverable{% endif %}">
     <div class="position-relative container p-0">
       <div class="row">
         <!-- Prompt col -->
@@ -16,27 +16,27 @@
           </div>
         {% endif %}
         <!-- Text col -->
-        <div class="{% if disable_native_text and post.postimage_set.all %} col-md-6 col-12 {% else %} col-12 {% endif %}">
+        <div class="{% if not is_detailed_view and post.postimage_set.all %} col-md-6 col-12 {% else %} col-12 {% endif %}">
           <h5 lang="{{ post.language.code }}">{{ post.title }}</h5>
           <p lang="{{ post.language.code }}"
-             class="mb-0 {% if not disable_text_truncation %}truncate-text line-clamp-10{% endif %}">
+             class="mb-0 {% if not is_detailed_view %}truncate-text line-clamp-10{% endif %}">
             {{ post.text|linebreaksbr }}
           </p>
-          {% if not disable_native_text and post.native_text %}
+          {% if is_detailed_view and post.native_text %}
             <hr class="text-muted" />
             <p class="mt-3 text-muted">{{ post.native_text|linebreaksbr }}</p>
           {% endif %}
-          {% if not disable_stretched_link %}
+          {% if not is_detailed_view %}
             <a href="{{ post.get_absolute_url }}"
                class="stretched-link link-secondary"></a>
           {% endif %}
         </div>
         <!-- Image col -->
-        <div class="{% if disable_native_text %} col-md-6 col-12 {% else %} col-12 {% endif %} my-auto">
+        <div class="{% if not is_detailed_view %} col-md-6 col-12 {% else %} col-12 {% endif %} my-auto">
           {% if post.postimage_set.all %}
             <div class="container p-0">
               <div class="row justify-content-start align-items-center py-3">
-                <div class="col {% if disable_native_text %} col-12 {% else %} col-md-6 {% endif %}">
+                <div class="col {% if not is_detailed_view %} col-12 {% else %} col-md-6 {% endif %}">
                   {% for image in post.postimage_set.all %}
                     <img src="{{ image.get_image_url }}"
                          class="img-fluid pointer js-lightbox-img rounded"

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -5,7 +5,7 @@
   {% include "posts/partials/card_header.html" %}
   <div class="card-body {% if not is_detailed_view %}hoverable{% endif %}">
     <div class="position-relative container p-0">
-      <div class="row">
+      <div class="row row-gap-2">
         <!-- Prompt col -->
         {% if post.prompt %}
           <div class="col-12 border-start border-2 px-2 mb-2">
@@ -16,7 +16,7 @@
           </div>
         {% endif %}
         <!-- Text col -->
-        <div class="{% if not is_detailed_view and post.postimage_set.all %} col-md-6 col-12 {% else %} col-12 {% endif %}">
+        <div class="{% if is_detailed_view %} col-12 {% elif post.postimage_set.all %} col-md-6 col-12 {% endif %}">
           <h5 lang="{{ post.language.code }}">{{ post.title }}</h5>
           <p lang="{{ post.language.code }}"
              class="mb-0 {% if not is_detailed_view %}truncate-text line-clamp-10{% endif %}">
@@ -32,11 +32,11 @@
           {% endif %}
         </div>
         <!-- Image col -->
-        <div class="{% if not is_detailed_view %} col-md-6 col-12 {% else %} col-12 {% endif %} my-auto">
+        <div class="{% if is_detailed_view %} col-12 {% else %} col-md-6 col-12 {% endif %} my-auto">
           {% if post.postimage_set.all %}
             <div class="container p-0">
-              <div class="row justify-content-start align-items-center py-3">
-                <div class="col {% if not is_detailed_view %} col-12 {% else %} col-md-6 {% endif %}">
+              <div class="row justify-content-start align-items-center">
+                <div class="{% if is_detailed_view %} col-md-6 {% else %} col-12 {% endif %}">
                   {% for image in post.postimage_set.all %}
                     <img src="{{ image.get_image_url }}"
                          class="img-fluid pointer js-lightbox-img rounded"

--- a/langcorrect/templates/posts/post_detail.html
+++ b/langcorrect/templates/posts/post_detail.html
@@ -10,7 +10,7 @@
 {% endblock title %}
 {% block content %}
   <div class="d-flex flex-column gap-3">
-    {% render_post_card instance=post current_user=request.user correctors=post.get_correctors disable_stretched_link=True disable_text_truncation=True %}
+    {% render_post_card instance=post current_user=request.user correctors=post.get_correctors is_detailed_view=True %}
     <div class="card">
       <div class="p-1 px-3 d-flex justify-content-between align-items-center">
         <span>{% translate "Corrections" %}</span>

--- a/langcorrect/templates/posts/post_detail.html
+++ b/langcorrect/templates/posts/post_detail.html
@@ -11,21 +11,6 @@
 {% block content %}
   <div class="d-flex flex-column gap-3">
     {% render_post_card instance=post current_user=request.user correctors=post.get_correctors disable_stretched_link=True disable_text_truncation=True %}
-    {% if post.postimage_set.all %}
-      <div class="card">
-        <div class="card-header">{% translate "Attachments" %}</div>
-        <div class="d-grid gap-3 p-3">
-          {% for image in post.postimage_set.all %}
-            <img src="{{ image.get_image_url }}"
-                 class="img-thumbnail pointer js-lightbox-img"
-                 alt="image"
-                 height="100"
-                 width="100"
-                 data-img-src="{{ image.get_image_url }}" />
-          {% endfor %}
-        </div>
-      </div>
-    {% endif %}
     <div class="card">
       <div class="p-1 px-3 d-flex justify-content-between align-items-center">
         <span>{% translate "Corrections" %}</span>

--- a/langcorrect/templates/posts/post_list.html
+++ b/langcorrect/templates/posts/post_list.html
@@ -57,7 +57,7 @@
       {% endif %}
       <div class="d-grid gap-3">
         {% for post in object_list %}
-          {% render_post_card instance=post current_user=request.user correctors=post.get_correctors disable_native_text=True %}
+          {% render_post_card instance=post current_user=request.user correctors=post.get_correctors %}
         {% endfor %}
         {% include "pagination.html" %}
       </div>

--- a/langcorrect/templates/users/user_detail.html
+++ b/langcorrect/templates/users/user_detail.html
@@ -146,7 +146,7 @@
           </div>
         </div>
         {% for post in posts %}
-          {% render_post_card instance=post current_user=request.user correctors=post.get_correctors disable_native_text=True %}
+          {% render_post_card instance=post current_user=request.user correctors=post.get_correctors %}
         {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
- [x] Clearer instructions for image attachment (file types & size supported, and premium feature indication)
- [x] In post detail view, show image at the end of post
- [x] In other views, show image side by side with the text preview for medium and up screens, and in a single column for small screens  