### PR TITLE
Adds filtering by post author's native languages to post list

### DIFF
--- a/langcorrect/posts/helpers.py
+++ b/langcorrect/posts/helpers.py
@@ -1,5 +1,8 @@
 from django.conf import settings
+from django.db.models import Count, Q
+from django.db.models.query import QuerySet
 
+from langcorrect.languages.models import Language, LevelChoices
 from langcorrect.posts.models import Post
 
 
@@ -9,6 +12,43 @@ def get_post_counts_by_language(languages, corrected=False):
     for language in languages:
         count = Post.available_objects.filter(language=language, is_corrected=corrected).count()
         data[language] = count
+
+    return data
+
+
+def get_post_counts_by_author_native_language(
+    native_languages: "QuerySet[Language]", selected_lang_code: str | None = None, corrected: bool = False
+) -> dict[Language, int]:
+    """
+    Returns a dictionary containing the count of posts based on the post author's native language.
+
+    :param native_languages: A QuerySet of Language objects representing authors' native languages
+    :param selected_lang_code: Optional. If provided, filters posts based on the language code.
+    :param corrected: Optional. If True, considers only corrected posts; otherwise, includes all posts.
+    :return: A dictionary where keys are Language objects and values are the corresponding post counts.
+    """
+    data = {}
+
+    if selected_lang_code and selected_lang_code is not None:
+        selected_lang_code_filter = Q(language__code=selected_lang_code)
+    else:
+        selected_lang_code_filter = Q()
+
+    qs = (
+        Post.available_objects.filter(
+            selected_lang_code_filter,
+            is_corrected=corrected,
+            user__languagelevel__level=LevelChoices.NATIVE,
+            user__languagelevel__language__in=native_languages,
+        )
+        .values("user__languagelevel__language")
+        .annotate(count=Count("id"))
+    )
+
+    # Build Language to count dictionary from language_id to count
+    language_id_to_count = {item["user__languagelevel__language"]: item["count"] for item in qs}
+    for language in native_languages:
+        data[language] = language_id_to_count.get(language.id, 0)
 
     return data
 

--- a/langcorrect/posts/helpers.py
+++ b/langcorrect/posts/helpers.py
@@ -29,7 +29,7 @@ def get_post_counts_by_author_native_language(
     """
     data = {}
 
-    if selected_lang_code and selected_lang_code is not None:
+    if selected_lang_code is not None and selected_lang_code != "all":
         selected_lang_code_filter = Q(language__code=selected_lang_code)
     else:
         selected_lang_code_filter = Q()

--- a/langcorrect/static/js/post_list.js
+++ b/langcorrect/static/js/post_list.js
@@ -7,4 +7,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const link = selectedOption.dataset.link;
     window.location = link;
   });
+
+  const authorNativeLanguageSelect = document.getElementById(
+    'author-native-language-select',
+  );
+  authorNativeLanguageSelect.addEventListener('change', function (evt) {
+    const selectedOption = evt.target.options[evt.target.selectedIndex];
+    const link = selectedOption.dataset.link;
+    window.location = link;
+  });
 });

--- a/langcorrect/templates/posts/post_list.html
+++ b/langcorrect/templates/posts/post_list.html
@@ -37,16 +37,31 @@
                class="link-secondary text-decoration-none {% if mode == 'following' %}link-dark fw-bold{% endif %}">{% translate "Following" %}</a>
           </div>
           <div class="d-flex gap-3 align-items-center ">
+            <i class="fa-solid fa-comment text-muted"></i>
+            <select id="author-native-language-select"
+                    class="form-select"
+                    aria-label="Filter posts by their author's native languages">
+              <option value="all"
+                      data-link="?mode={{ mode }}&author_native_lang_code=all&lang_code={{ selected_lang_code }}"
+                      {% if selected_author_native_lang_code == "all" %}selected{% endif %}>All</option>
+              {% for language, count in author_native_language_filters.items %}
+                <option value="{{ language.code }}"
+                        data-link="?mode={{ mode }}&author_native_lang_code={{ language.code }}&lang_code={{ selected_lang_code }}"
+                        {% if selected_author_native_lang_code == language.code %}selected{% endif %}>
+                  {% translate language.code %} ({{ count }})
+                </option>
+              {% endfor %}
+            </select>
             <i class="fa-solid fa-globe text-muted"></i>
             <select id="language-select"
                     class="form-select"
-                    aria-label="Default select example">
-              <option value="{{ language.code }}"
-                      data-link="?mode={{ mode }}&lang_code=all"
+                    aria-label="Filter posts by your native languages">
+              <option value="all"
+                      data-link="?mode={{ mode }}&author_native_lang_code={{ selected_author_native_lang_code }}&lang_code=all"
                       {% if selected_lang_code == "all" %}selected{% endif %}>All</option>
               {% for language, count in language_filters.items %}
                 <option value="{{ language.code }}"
-                        data-link="?mode={{ mode }}&lang_code={{ language.code }}"
+                        data-link="?mode={{ mode }}&author_native_lang_code={{ selected_author_native_lang_code }}&lang_code={{ language.code }}"
                         {% if selected_lang_code == language.code %}selected{% endif %}>
                   {% translate language.code %} ({{ count }})
                 </option>


### PR DESCRIPTION
Adds additional dropdown to filter posts by the author's native language with test.

* Adds another select option with new variables for author native languages, modifying `data-link` accordingly
* Shows counts of posts that would be shown by the filter, same as before

Looking for any feedback, from code cleanliness and best practices, better ideas for logos for clarity, and suggestions to improve mobile if any.

Examples from local browser below:
<img width="873" alt="Screenshot 2024-01-17 at 4 53 01 PM" src="https://github.com/LangCorrect/server/assets/59217250/6a6ad6dc-ff3b-4be4-a90c-780eece21f1d">

<img width="1446" alt="Screenshot 2024-01-17 at 4 53 39 PM" src="https://github.com/LangCorrect/server/assets/59217250/a0d38699-cb69-4768-98de-9826d1faaff1">

<img width="413" alt="Screenshot 2024-01-17 at 4 56 13 PM" src="https://github.com/LangCorrect/server/assets/59217250/3efdeae4-243d-46bb-9ee9-858066af8107">
