### PR TITLE
Adds badge for post tag to post_card (#414)

### DIFF
--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -26,7 +26,9 @@
         <a href="{{ post.get_absolute_url }}"
            class="stretched-link link-secondary"></a>
       {% endif %}
-      {% for tag in post.tags.names %}<span class="badge bg-secondary me-1">{{ tag }}</span>{% endfor %}
+      <div class="mt-3">
+        {% for tag in post.tags.names %}<span class="badge bg-secondary me-1">{{ tag }}</span>{% endfor %}
+      </div>
     </div>
   </div>
   <div class="card-footer bg-transparent">

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -20,15 +20,17 @@
       </p>
       {% if not disable_native_text and post.native_text %}
         <hr class="text-muted" />
-        <p class="mt-3 text-muted">{{ post.native_text|linebreaksbr }}</p>
+        <p class="mt-3 mb-0 text-muted">{{ post.native_text|linebreaksbr }}</p>
       {% endif %}
       {% if not disable_stretched_link %}
         <a href="{{ post.get_absolute_url }}"
            class="stretched-link link-secondary"></a>
       {% endif %}
-      <div class="mt-3">
-        {% for tag in post.tags.names %}<span class="badge bg-secondary me-1">{{ tag }}</span>{% endfor %}
-      </div>
+      {% if post.tags.names %}
+        <div class="mt-3">
+          {% for tag in post.tags.names %}<span class="badge bg-secondary me-1">{{ tag }}</span>{% endfor %}
+        </div>
+      {% endif %}
     </div>
   </div>
   <div class="card-footer bg-transparent">

--- a/langcorrect/templates/posts/partials/post_card.html
+++ b/langcorrect/templates/posts/partials/post_card.html
@@ -26,6 +26,7 @@
         <a href="{{ post.get_absolute_url }}"
            class="stretched-link link-secondary"></a>
       {% endif %}
+      {% for tag in post.tags.names %}<span class="badge bg-secondary me-1">{{ tag }}</span>{% endfor %}
     </div>
   </div>
   <div class="card-footer bg-transparent">


### PR DESCRIPTION
fixes #414 

Adds tags to posts as badges.
Appears at the bottom of text.
Not clickable yet, but since there is no existing tag search functionality, probably better in a separate PR

<img width="1141" alt="Screenshot 2024-01-18 at 3 48 26 PM" src="https://github.com/LangCorrect/server/assets/59217250/ab3b4c14-55af-4fb9-bdb3-9f0fc6a83600">
