### PR TITLE
Orders user profile languages by -level (#357)

### DIFF
--- a/langcorrect/templates/users/user_detail.html
+++ b/langcorrect/templates/users/user_detail.html
@@ -67,7 +67,7 @@
               <i class="fa-solid fa-language"></i> {% translate "Languages" %}
             </h6>
             <ul class="list-unstyled">
-              {% for ll in object.languagelevel_set.all %}<li>{{ ll }}</li>{% endfor %}
+              {% for ll in languages %}<li>{{ ll }}</li>{% endfor %}
             </ul>
           </div>
           <div class="card-body border-bottom">

--- a/langcorrect/users/views.py
+++ b/langcorrect/users/views.py
@@ -24,6 +24,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
         start_date = timezone.make_aware(datetime(now.year, 1, 1))
         end_date = timezone.make_aware(datetime(now.year, 12, 31, 23, 59, 59))
 
+        language_levels_ordered = user.languagelevel_set.order_by("-level")
         post_this_year_count = user.post_set.filter(created__range=(start_date, end_date)).count()
         corrections_this_year_count = user.correctedrow_set.filter(created__range=(start_date, end_date)).count()
         perfects_this_year_count = user.perfectrow_set.filter(created__range=(start_date, end_date)).count()
@@ -37,6 +38,7 @@ class UserDetailView(LoginRequiredMixin, DetailView):
                 + prompts_this_year_count,
                 "posts": user.post_set.all()[:10],
                 "is_following": True if self.request.user in user.followers_users else False,
+                "languages": language_levels_ordered,
             }
         )
         return context


### PR DESCRIPTION
fixes #357 

Before
<img width="325" alt="Screenshot 2024-01-18 at 9 02 40 PM" src="https://github.com/LangCorrect/server/assets/59217250/70344cc5-b3bd-49c9-bfef-305857b0da20">

After
<img width="329" alt="Screenshot 2024-01-18 at 9 12 14 PM" src="https://github.com/LangCorrect/server/assets/59217250/f8f352f3-4777-4035-9728-9e71bc6d1784">
