### PR TITLE
423 Confirm Before Erasing Correction [WIP]

### DIFF
--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -336,27 +336,32 @@
     function handleDeleteButtonClick(e, btn, corrections) {
       e.preventDefault();
 
-      const id = btn.getAttribute("data-sentence-id");
-      const correction = corrections.find(c => c.sentence_id === id);
-      correction.action = "delete";
+      customConfirm(() => {
+        const id = btn.getAttribute("data-sentence-id");
+        const correction = corrections.find(c => c.sentence_id === id);
+        correction.action = "delete";
 
-      const correctionTextarea = document.getElementById(`js-correction-row-${id}`);
-      correctionTextarea.disabled = true;
+        const correctionTextarea = document.getElementById(`js-correction-row-${id}`);
+        correctionTextarea.disabled = true;
 
-      const feedbackTextarea = document.getElementById(`js-correction-note-${id}`);
-      feedbackTextarea.disabled = true;
+        const feedbackTextarea = document.getElementById(`js-correction-note-${id}`);
+        feedbackTextarea.disabled = true;
 
-      const correctionBox = document.querySelector(`[data-correction-box="${id}"]`);
-      correctionBox.classList.add("d-none");
+        const correctionBox = document.querySelector(`[data-correction-box="${id}"]`);
+        correctionBox.classList.add("d-none");
 
-      btn.disabled = true;
+        btn.disabled = true;
+      })
     }
 
     function handleDeleteFeedbackButtonClick(e, btn) {
       e.preventDefault();
-      btn.disabled = true;
-      const deleteFeedbackInput = document.getElementById("deleteOverallFeedback");
-      deleteFeedbackInput.value = "true";
+
+      customConfirm(() => {
+        btn.disabled = true;
+        const deleteFeedbackInput = document.getElementById("deleteOverallFeedback");
+        deleteFeedbackInput.value = "true";
+      })
     }
 
     function setupFormSubmitListener(corrections) {

--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -280,16 +280,14 @@
         correctionBox.classList.toggle("d-none");
         icon.classList.toggle('fa-pen');
         icon.classList.toggle('fa-undo');
+        perfectBtn.disabled = true;
       } else if (correction.action === "corrected") {
-        customConfirm(function(confirmed) {
-          if (confirmed) {
-            correction.action = "none";
-            correctionBox.classList.toggle("d-none");
-            icon.classList.toggle('fa-pen');
-            icon.classList.toggle('fa-undo');
-            perfectBtn.disabled = correction.action === "corrected";
-            console.log(`done ${id}`);
-          }
+        customConfirm(() => {
+          correction.action = "none";
+          correctionBox.classList.toggle("d-none");
+          icon.classList.toggle('fa-pen');
+          icon.classList.toggle('fa-undo');
+          perfectBtn.disabled = false;
         })
       }
 
@@ -300,14 +298,11 @@
     function customConfirm(callback) {
       const modal = new bootstrap.Modal("#reset-modal");
       modal.show();
-
       const modalEl = document.querySelector("#reset-modal");
-      modalEl.querySelector("#reset-modal-cancel").addEventListener("click", handleResetModalCancel);
       modalEl.querySelector("#reset-modal-confirm").addEventListener("click", handleResetModalConfirm);
 
       function removeModal() {
         modal.hide();
-        modalEl.querySelector("#reset-modal-cancel").removeEventListener("click", handleResetModalCancel);
         modalEl.querySelector("#reset-modal-confirm").removeEventListener("click", handleResetModalConfirm);
       }
 
@@ -315,15 +310,9 @@
         removeModal();
       });
 
-      function handleResetModalCancel(e) {
-        e.preventDefault();
-        callback(false);
-        removeModal();
-      }
-
       function handleResetModalConfirm(e) {
         e.preventDefault();
-        callback(true);
+        callback();
         removeModal();
       }
     }

--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -281,8 +281,8 @@
         icon.classList.toggle('fa-pen');
         icon.classList.toggle('fa-undo');
       } else if (correction.action === "corrected") {
-        customConfirm(function(res) {
-          if (res) {
+        customConfirm(function(confirmed) {
+          if (confirmed) {
             correction.action = "none";
             correctionBox.classList.toggle("d-none");
             icon.classList.toggle('fa-pen');
@@ -302,21 +302,29 @@
       modal.show();
 
       const modalEl = document.querySelector("#reset-modal");
-      modalEl.querySelector("#reset-modal-cancel").removeEventListener("click", handleResetModalCancel);
-      modalEl.querySelector("#reset-modal-confirm").removeEventListener("click", handleResetModalConfirm);
       modalEl.querySelector("#reset-modal-cancel").addEventListener("click", handleResetModalCancel);
       modalEl.querySelector("#reset-modal-confirm").addEventListener("click", handleResetModalConfirm);
+
+      function removeModal() {
+        modal.hide();
+        modalEl.querySelector("#reset-modal-cancel").removeEventListener("click", handleResetModalCancel);
+        modalEl.querySelector("#reset-modal-confirm").removeEventListener("click", handleResetModalConfirm);
+      }
+
+      modalEl.addEventListener("hidden.bs.modal", () => {
+        removeModal();
+      });
 
       function handleResetModalCancel(e) {
         e.preventDefault();
         callback(false);
-        modal.hide();
+        removeModal();
       }
 
       function handleResetModalConfirm(e) {
         e.preventDefault();
         callback(true);
-        modal.hide()
+        removeModal();
       }
     }
 

--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -139,6 +139,7 @@
 {% block modal %}
   {{ block.super }}
   {% include "modals/discard_modal.html" %}
+  {% include "modals/reset_modal.html" %}
   {% include "modals/native_text.html" %}
 {% endblock modal %}
 {% block inline_javascript %}
@@ -271,20 +272,52 @@
       const correctionTextarea = document.getElementById(`js-correction-row-${id}`);
       const feedbackTextarea = document.getElementById(`js-correction-note-${id}`);
 
-      correction.action = correction.action === "corrected" ? "none" : "corrected";
-      correctionBox.classList.toggle("d-none");
-      icon.classList.toggle('fa-pen');
-      icon.classList.toggle('fa-undo');
-
       if (correction.action === "none") {
+        correction.action = "corrected";
         correctionTextarea.value = correction.original_text;
         feedbackTextarea.value = "";
+
+        correctionBox.classList.toggle("d-none");
+        icon.classList.toggle('fa-pen');
+        icon.classList.toggle('fa-undo');
+      } else if (correction.action === "corrected") {
+        customConfirm(function(res) {
+          if (res) {
+            correction.action = "none";
+            correctionBox.classList.toggle("d-none");
+            icon.classList.toggle('fa-pen');
+            icon.classList.toggle('fa-undo');
+            perfectBtn.disabled = correction.action === "corrected";
+            console.log(`done ${id}`);
+          }
+        })
       }
 
       autosize.update(correctionTextarea);
       autosize.update(feedbackTextarea);
+    }
 
-      perfectBtn.disabled = correction.action === "corrected";
+    function customConfirm(callback) {
+      const modal = new bootstrap.Modal("#reset-modal");
+      modal.show();
+
+      const modalEl = document.querySelector("#reset-modal");
+      modalEl.querySelector("#reset-modal-cancel").removeEventListener("click", handleResetModalCancel);
+      modalEl.querySelector("#reset-modal-confirm").removeEventListener("click", handleResetModalConfirm);
+      modalEl.querySelector("#reset-modal-cancel").addEventListener("click", handleResetModalCancel);
+      modalEl.querySelector("#reset-modal-confirm").addEventListener("click", handleResetModalConfirm);
+
+      function handleResetModalCancel(e) {
+        e.preventDefault();
+        callback(false);
+        modal.hide();
+      }
+
+      function handleResetModalConfirm(e) {
+        e.preventDefault();
+        callback(true);
+        modal.hide()
+      }
     }
 
     function setupDeleteButtonListeners(corrections) {

--- a/langcorrect/templates/modals/reset_modal.html
+++ b/langcorrect/templates/modals/reset_modal.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+
+<div id="reset-modal" class="modal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered modal-md">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{% translate "Are you sure?" %}</h5>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">{% translate "The correction for this sentence will be reset" %}</div>
+      <div class="modal-footer">
+        <button type="button"
+                class="btn btn-outline-secondary"
+                data-bs-dismiss="modal"
+                id="reset-modal-cancel">{% translate "Cancel" %}</button>
+        <button type="button" class="btn btn-danger" id="reset-modal-confirm">{% translate "Reset" %}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/langcorrect/templates/modals/reset_modal.html
+++ b/langcorrect/templates/modals/reset_modal.html
@@ -14,8 +14,7 @@
       <div class="modal-footer">
         <button type="button"
                 class="btn btn-outline-secondary"
-                data-bs-dismiss="modal"
-                id="reset-modal-cancel">{% translate "Cancel" %}</button>
+                data-bs-dismiss="modal">{% translate "Cancel" %}</button>
         <button type="button" class="btn btn-danger" id="reset-modal-confirm">{% translate "Reset" %}</button>
       </div>
     </div>

--- a/langcorrect/templates/modals/reset_modal.html
+++ b/langcorrect/templates/modals/reset_modal.html
@@ -15,7 +15,7 @@
         <button type="button"
                 class="btn btn-outline-secondary"
                 data-bs-dismiss="modal">{% translate "Cancel" %}</button>
-        <button type="button" class="btn btn-danger" id="reset-modal-confirm">{% translate "Reset" %}</button>
+        <button type="button" class="btn btn-danger" id="reset-modal-confirm">{% translate "Confirm" %}</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes #423 

I've further simplified the function and it turns out that the bool inside the callback we were discussing earlier doesn't actually need to be there.

Besides, I've also used this modal for the delete buttons in the edit corrections page. I also think it would make sense to slightly change the modal body text depending on where it's used, but I don't know how to programmatically update it together with the translations.