### PR TITLE
Bypass cache when querying for notification count (#401)

### DIFF
--- a/langcorrect/templates/navbar.html
+++ b/langcorrect/templates/navbar.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 {% load static %}
-{% load notifications_tags %}
 
-{% notifications_unread as unread_count %}
 <nav class="navbar navbar-expand-md navbar-light bg-white border-bottom">
   <div class="container  align-items-center">
     <a class="navbar-brand" href="{% url 'home' %}">
@@ -18,11 +16,11 @@
       </a>
       {% if request.user.is_authenticated %}
         <button id="notification-button"
-                class="btn {% if unread_count %} btn-primary {% else %} text-muted {% endif %} me-2 d-md-none"
+                class="btn {% if request.user.notifications.unread.count %} btn-primary {% else %} text-muted {% endif %} me-2 d-md-none"
                 data-bs-toggle="modal"
                 data-bs-target="#mobileNotifications">
           <i class="fas fa-bell fa-fw"></i>
-          {{ unread_count }}
+          {{ request.user.notifications.unread.count }}
         </button>
       {% endif %}
       <button class="navbar-toggler p-2"
@@ -79,11 +77,11 @@
           </li>
           <li class="d-none d-md-block">
             <button id="notification-button"
-                    class="btn {% if unread_count %} btn-primary {% else %} text-muted {% endif %} me-2"
+                    class="btn {% if request.user.notifications.unread.count %} btn-primary {% else %} text-muted {% endif %} me-2"
                     data-bs-toggle="modal"
                     data-bs-target="#mobileNotifications">
               <i class="fas fa-bell fa-fw"></i>
-              {{ unread_count }}
+              {{ request.user.notifications.unread.count }}
             </button>
           </li>
           <li class="dropdown d-inline-block mt-2 mt-md-0">


### PR DESCRIPTION
There is a current ongoing production issue (#401) where ghost notification counts are sporadically displayed. To address this problem, this PR implements a temp fix that retrieves the unread notification count without relying on the cache. By doing so, we can investigate whether the issue is connected to the caching mechanism.