### PR TITLE
Show indicator for post title (#468)

### DIFF
--- a/langcorrect/corrections/views.py
+++ b/langcorrect/corrections/views.py
@@ -174,6 +174,7 @@ def make_corrections(request, slug):
             post_row.show_form = False
             post_row.is_action_taken = False
             post_row.action = "none"
+            post_row.is_title = post_row.order == 0
 
             if previous_correction:
                 post_row.correction = previous_correction.correction

--- a/langcorrect/templates/corrections/make_corrections.html
+++ b/langcorrect/templates/corrections/make_corrections.html
@@ -47,7 +47,15 @@
                data-original-sentence="{{ post_row.sentence }}"
                data-action="{{ post_row.action }}">
             <div class="card-body border-bottom">
-              <span lang="{{ post.language.code }}" class="js-sentence">{{ post_row.sentence }}</span>
+              <span lang="{{ post.language.code }}" class="js-sentence">
+                {% if post_row.is_title %}
+                  <span class="badge text-bg-light pointer"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="bottom"
+                        data-bs-title="{% translate 'Ensure post titles are correctly formatted' %}">{% translate "Post title" %}</span>
+                {% endif %}
+                {{ post_row.sentence }}
+              </span>
             </div>
             <div class="card-body {% if not post_row.show_form %}d-none{% endif %} "
                  data-correction-box="{{ post_row.id }}">


### PR DESCRIPTION
fixes #468 

This PR adds an indicator for post title and shows a friendly tool-tip to remind users to correct the title accordingly

![image](https://github.com/LangCorrect/server/assets/115326106/95fae49a-fb9d-4f6e-a2d9-4cd3d79b433a)