### PR TITLE
145 prompts api

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -97,6 +97,7 @@ urlpatterns = [
 api_urlpatterns_v1 = [
     path("contributions/", include("langcorrect.contributions.urls")),
     path("users/", include("langcorrect.users.api.urls")),
+    path("prompts/", include("langcorrect.prompts.api.urls")),
 ]
 
 

--- a/langcorrect/prompts/api/urls.py
+++ b/langcorrect/prompts/api/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from langcorrect.prompts.api.views import PromptListCreateAPIView
+from langcorrect.prompts.api.views import PromptRetrieveUpdateDestroyAPIView
+
+urlpatterns = [
+    path("", view=PromptListCreateAPIView.as_view(), name="prompt-list-create"),
+    path(
+        "<str:slug>/",
+        view=PromptRetrieveUpdateDestroyAPIView.as_view(),
+        name="prompt-detail",
+    ),
+]

--- a/langcorrect/prompts/api/views.py
+++ b/langcorrect/prompts/api/views.py
@@ -1,0 +1,53 @@
+from rest_framework import generics
+
+from config.api.permissions import IsOwnerOrStaff
+from langcorrect.prompts.api.serializers import PromptSerializer
+from langcorrect.prompts.models import Prompt
+
+
+class PromptListCreateAPIView(generics.ListCreateAPIView):
+    queryset = Prompt.objects.all()
+    serializer_class = PromptSerializer
+
+    def get_queryset(self):
+        queryset = self.queryset.select_related(
+            "user",
+            "language",
+            "challenge",
+        ).prefetch_related("tags")
+
+        search = self.request.query_params.get("search")
+        langs = self.request.query_params.get("langs")
+
+        if search:
+            queryset = queryset.filter(content__icontains=search)
+
+        if langs:
+            codes = langs.split(",")
+            queryset = queryset.filter(language__code__in=codes)
+
+        return queryset
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
+
+class PromptRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Prompt.objects.all()
+    serializer_class = PromptSerializer
+    lookup_field = "slug"
+    permission_classes = [IsOwnerOrStaff]
+
+    def get_queryset(self):
+        return self.queryset.select_related(
+            "user",
+            "language",
+            "challenge",
+        ).prefetch_related("tags")
+
+    def perform_update(self, serializer):
+        updates = {}
+        language = serializer.validated_data.get("lang_code")
+        if language:
+            updates["language"] = language
+        serializer.save(user=self.request.user, **updates)

--- a/langcorrect/users/api/views.py
+++ b/langcorrect/users/api/views.py
@@ -11,8 +11,8 @@ from rest_framework.viewsets import GenericViewSet
 from langcorrect.posts.api.serializers import PostSerializer
 from langcorrect.posts.models import Post
 from langcorrect.posts.models import PostVisibility
+from langcorrect.prompts.api.serializers import PromptSerializer
 from langcorrect.prompts.models import Prompt
-from langcorrect.prompts.serializers import PromptSerializer
 
 from .serializers import UserSerializer
 


### PR DESCRIPTION
fixes #145 

```
 path(
        "<str:slug>/",
        view=PromptRetrieveUpdateDestroyAPIView.as_view(),
        name="prompt-detail",
    ),
```

I wasn't able to figure out a way to remove the trailing slash requirement without adding this path to the router or disabling it in settings completely. So for now, a trailing slash will be required until the full switch to an API backend is complete.