### PR TITLE
feat: exclude inactive users from qs

### DIFF
--- a/langcorrect/contributions/models.py
+++ b/langcorrect/contributions/models.py
@@ -4,6 +4,8 @@ from django.utils import timezone
 from model_utils.models import SoftDeletableModel
 from model_utils.models import TimeStampedModel
 
+from langcorrect.managers import ActiveUserSoftDeleteManager
+
 
 class Contribution(SoftDeletableModel, TimeStampedModel):
     class Meta:
@@ -16,6 +18,7 @@ class Contribution(SoftDeletableModel, TimeStampedModel):
     prompt_count = models.IntegerField(default=0)
     rank = models.IntegerField(default=0)
     writing_streak = models.IntegerField(default=0)
+    objects = ActiveUserSoftDeleteManager()
 
     @property
     def get_average_per_day(self):

--- a/langcorrect/managers.py
+++ b/langcorrect/managers.py
@@ -1,0 +1,6 @@
+from model_utils.managers import SoftDeletableManager
+
+
+class ActiveUserSoftDeleteManager(SoftDeletableManager):
+    def get_queryset(self):
+        return super().get_queryset().filter(user__is_active=True)

--- a/langcorrect/posts/models.py
+++ b/langcorrect/posts/models.py
@@ -9,13 +9,13 @@ from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext_noop
-from model_utils.managers import SoftDeletableManager
 from model_utils.models import SoftDeletableModel
 from model_utils.models import TimeStampedModel
 from notifications.signals import notify
 from taggit.managers import TaggableManager
 
 from langcorrect.languages.models import LevelChoices
+from langcorrect.managers import ActiveUserSoftDeleteManager
 from langcorrect.posts.utils import SentenceSplitter
 from langcorrect.users.models import GenderChoices
 from langcorrect.users.models import User
@@ -26,11 +26,6 @@ sentence_splitter = SentenceSplitter()
 class PostVisibility(models.TextChoices):
     PUBLIC = "public", _("Viewable by everyone")
     MEMBER = "member", _("Viewable only by registered members")
-
-
-class ActiveUserSoftDeleteManager(SoftDeletableManager):
-    def get_queryset(self):
-        return super().get_queryset().filter(user__is_active=True)
 
 
 class Post(TimeStampedModel, SoftDeletableModel):

--- a/langcorrect/templates/posts/partials/card_badges.html
+++ b/langcorrect/templates/posts/partials/card_badges.html
@@ -1,34 +1,36 @@
 {% load i18n %}
 
-<div class="d-flex align-items-center gap-1">
-  <span class="d-flex align-items-center"
-        data-bs-toggle="tooltip"
-        data-bs-placement="bottom"
-        data-bs-title="{% translate 'Writing Streak' %}">
-    <span class="fa-stack small">
-      <i class="fa-solid fa-circle fa-stack-2x text-light outlined"></i>
-      <i class="fa-solid fa-fire fa-stack-1x fa-inverse text-danger"></i>
+{% if user.is_active %}
+  <div class="d-flex align-items-center gap-1">
+    <span class="d-flex align-items-center"
+          data-bs-toggle="tooltip"
+          data-bs-placement="bottom"
+          data-bs-title="{% translate 'Writing Streak' %}">
+      <span class="fa-stack small">
+        <i class="fa-solid fa-circle fa-stack-2x text-light outlined"></i>
+        <i class="fa-solid fa-fire fa-stack-1x fa-inverse text-danger"></i>
+      </span>
+      {{ user.writing_streak }}
     </span>
-    {{ user.writing_streak }}
-  </span>
-  {% for studying_language in current_user.studying_languages %}
-    {% if studying_language in user.native_languages %}
+    {% for studying_language in current_user.studying_languages %}
+      {% if studying_language in user.native_languages %}
+        <span class="fa-stack small"
+              data-bs-toggle="tooltip"
+              data-bs-placement="bottom"
+              data-bs-title="{% translate 'Language Match' %}">
+          <i class="fa-solid fa-circle fa-stack-2x text-light outlined"></i>
+          <i class="fa-solid fa-handshake fa-stack-1x fa-inverse text-primary"></i>
+        </span>
+      {% endif %}
+    {% endfor %}
+    {% if user.is_premium_user %}
       <span class="fa-stack small"
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
-            data-bs-title="{% translate 'Language Match' %}">
+            data-bs-title="{% translate 'Premium' %}">
         <i class="fa-solid fa-circle fa-stack-2x text-light outlined"></i>
-        <i class="fa-solid fa-handshake fa-stack-1x fa-inverse text-primary"></i>
+        <i class="fa-solid fa-crown fa-stack-1x fa-inverse text-premium"></i>
       </span>
     {% endif %}
-  {% endfor %}
-  {% if user.is_premium_user %}
-    <span class="fa-stack small"
-          data-bs-toggle="tooltip"
-          data-bs-placement="bottom"
-          data-bs-title="{% translate 'Premium' %}">
-      <i class="fa-solid fa-circle fa-stack-2x text-light outlined"></i>
-      <i class="fa-solid fa-crown fa-stack-1x fa-inverse text-premium"></i>
-    </span>
-  {% endif %}
-</div>
+  </div>
+{% endif %}

--- a/langcorrect/templates/posts/partials/card_header.html
+++ b/langcorrect/templates/posts/partials/card_header.html
@@ -4,12 +4,20 @@
 <div class="card-header bg-transparent">
   <div class="d-flex align-items-center justify-content-between">
     <div class="d-flex align-items-center gap-3">
-      <a href="{{ user.get_absolute_url }}">
-        <img src="{{ user.avatar }}" alt="{{ user.display_name }}'s avatar" />
-      </a>
+      {% if user.is_active %}
+        <a href="{{ user.get_absolute_url }}">
+          <img src="{{ user.avatar }}" alt="{{ user.display_name }}'s avatar" />
+        </a>
+      {% else %}
+        <i class="fa-solid fa-ghost text-primary fa-lg"></i>
+      {% endif %}
       <div>
-        <a href="{{ user.get_absolute_url }}"
-           class="card-title mb-0 text-decoration-none {% if user.is_premium_user %}text-premium{% else %}text-reset{% endif %}">{{ user.display_name }}</a>
+        {% if user.is_active %}
+          <a href="{{ user.get_absolute_url }}"
+             class="card-title mb-0 text-decoration-none {% if user.is_premium_user %}text-premium{% else %}text-reset{% endif %}">{{ user.display_name }}</a>
+        {% else %}
+          <span class="text-primary">Kindred Spirit</span>
+        {% endif %}
         <p class="mb-0 small text-muted">{{ created|naturalday }}</p>
       </div>
     </div>

--- a/langcorrect/users/models.py
+++ b/langcorrect/users/models.py
@@ -2,6 +2,7 @@
 import uuid
 
 from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import UserManager
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -14,6 +15,11 @@ from langcorrect.contributions.models import Contribution
 from langcorrect.corrections.models import PostCorrection
 from langcorrect.languages.models import Language
 from langcorrect.languages.models import LevelChoices
+
+
+class ActiveUserManager(UserManager):
+    def get_queryset(self):
+        return super().get_queryset().filter(is_active=True)
 
 
 class GenderChoices(models.TextChoices):
@@ -45,6 +51,8 @@ class User(AbstractUser):
     is_lifetime_vip = models.BooleanField(default=False)
     is_max_studying = models.BooleanField(default=False)
     uuid = models.UUIDField(null=True, blank=True, default=uuid.uuid4, editable=False)
+
+    objects = ActiveUserManager()
 
     def get_absolute_url(self) -> str:
         """Get URL for user's detail view.


### PR DESCRIPTION
This PR excludes inactive users from various querysets to ensure they are not shown where active user data is expected.

In some cases (e.g., displaying corrections on a post), inactive users are not excluded; instead, their user information is replaced with a cute default avatar and name.

![image](https://github.com/user-attachments/assets/402ca6a7-edb4-4145-8a9e-f19efdacb16a)
